### PR TITLE
Command line flags should resolve build variables

### DIFF
--- a/src/main/java/eggPlant/eggPlantBuilder.java
+++ b/src/main/java/eggPlant/eggPlantBuilder.java
@@ -269,12 +269,11 @@ public class eggPlantBuilder extends Builder {
         }
 
         EggplantParser parser = new EggplantParser();
-        scripts = script.split(",");
 
         //  Get the files in the build job directory
         File[] files = build.getRootDir().listFiles();
         boolean passed = true;
-        int j = 0;//script counter
+
         //  Loop round all the files
         for (int i = 0; i < files.length; i++)
         {
@@ -287,8 +286,11 @@ public class eggPlantBuilder extends Builder {
                 //  then nothing will be logged
                 String startDir = file.getAbsolutePath();
                 listener.getLogger().println("Results Dir: " + startDir);
-                passed &= parser.parseResult(action, startDir, build.getUrl(),scripts[j],sut);
-                j++;
+
+                String scriptName = file.getName();   //same as the directory name
+                listener.getLogger().println("Script name: " + scriptName);
+
+                passed &= parser.parseResult(action, startDir, build.getUrl(),scriptName,sut);
             }
         }
 

--- a/src/main/java/eggPlant/eggPlantBuilder.java
+++ b/src/main/java/eggPlant/eggPlantBuilder.java
@@ -2,6 +2,7 @@ package eggPlant;
 
 import hudson.Launcher;
 import hudson.Extension;
+import hudson.Util;
 import hudson.util.FormValidation;
 import hudson.model.AbstractBuild;
 import hudson.model.BuildListener;
@@ -22,38 +23,38 @@ import java.io.IOException;
 
 public class eggPlantBuilder extends Builder {
 
-    
+
     private final String script;
     private final String sut;
     private final String port;
     private final String password;
     private final String colorDepth;
-    
+
     private final String globalResultsFolder;
     private final String defaultDocumentDirectory;
     private final String params;
     private final boolean reportFailures;
     private final boolean commandLineOutput;
-    
+
     //operating system... it appears that Jenkins on Mac/Linux doesn't like quotes in the command
     private String operatingSystem;
-    private String[] scripts; 
+    private String[] scripts;
     private String commandLine; //location of runscript
 
-    
+
     // Fields in config.jelly must match the parameter names in the "DataBoundConstructor"
     @DataBoundConstructor
     public eggPlantBuilder(String script,
                            String SUT,
-                           String port, 
-                           String password, 
-                           String colorDepth, 
+                           String port,
+                           String password,
+                           String colorDepth,
                            String globalResultsFolder,
                            String defaultDocumentDirectory,
                            String params,
                            boolean reportFailures,
                            boolean commandLineOutput) {
-        
+
         this.script = script;
         this.sut = SUT;
         this.port = port;
@@ -64,7 +65,7 @@ public class eggPlantBuilder extends Builder {
         this.params = params;
         this.reportFailures = reportFailures;
         this.commandLineOutput = commandLineOutput;
-        
+
     }
 
     /**
@@ -80,7 +81,7 @@ public class eggPlantBuilder extends Builder {
             return "/usr/local/bin/runscript";
         }
     }
-    
+
     public String getCommandLine() {
         return commandLine;
     }
@@ -104,13 +105,31 @@ public class eggPlantBuilder extends Builder {
     public String getColorDepth() {
         return colorDepth;
     }
-    
+
+    private String getResolvedString(String str, AbstractBuild build, BuildListener listener) throws Exception {
+        if (str == null) {
+            return null;
+        }
+
+        String resolvedStr;
+
+        try {
+            resolvedStr = Util.replaceMacro(str, build.getEnvironment(listener));
+            resolvedStr = Util.replaceMacro(resolvedStr, build.getBuildVariables());
+            return resolvedStr;
+        } catch (IOException ioe) {
+            throw new Exception(ioe);
+        } catch (InterruptedException ie) {
+            throw new Exception(ie);
+        }
+    }
+
     //ajf 10/26/11 added getter for default doc dir
-    
+
     public String getDefaultDocumentDirectory(){
         return defaultDocumentDirectory;
     }
-    
+
     //ajf 10/18/11: may Need to do some OS-Specific things when building the runscript path...
     public String getOS() {
         if (operatingSystem == null) {
@@ -118,15 +137,15 @@ public class eggPlantBuilder extends Builder {
         }
         return operatingSystem;
     }
-    
+
     public boolean isWindows() {
         return getOS().startsWith("Windows");
     }
-    
+
     public boolean isMac() {
         return getOS().startsWith("Mac");
     }
-    
+
     public boolean isLinux() {
         //@TODO: this needs to be checked before it's used
         return getOS().startsWith("Linux");
@@ -136,61 +155,67 @@ public class eggPlantBuilder extends Builder {
      * This is where you 'build' the project. 
      * This runs eggPlant from the command line and then reads in the results
      * so that Jenkins can display them
-     * 
+     *
      * @param build
      * @param launcher
      * @param listener
-     * @return 
+     * @return
      */
     @Override
     public boolean perform(AbstractBuild build, Launcher launcher, BuildListener listener) {
         //  Start logging - this will appear in the console output
         listener.getLogger().println("eggPlant execution started");
-        
+
         //ajf 04/18/2012: pull runscript from the global store or use the default.
-        
+
         if (getDescriptor().getCommandLine() == null || getDescriptor().getCommandLine().isEmpty() ){
             this.commandLine = defaultCLI();
         } else {
-                    this.commandLine = getDescriptor().getCommandLine();
+            this.commandLine = getDescriptor().getCommandLine();
         }
         String epWorkingDir;
         String ls_str;
-        
+
         //ajf 10/21/11: rewrote in a more systemmatic fashion to fix 20016287
         //vars
         String assetsDir; //directory where eggPlant scripts exist
 
         try {
-             
+
             //Construct the command line execution
             RunscriptCommand runner = new RunscriptCommand(build,commandLine,script);
-            
+
             //Step 1: path to runscript--handled by the RunscriptCommand Object
             listener.getLogger().println("Command Step 1 - Runscript Location: " + runner.getRunscript());
-            
+
             //Step 2: Construct the list of scrips - handled by the runscript command object
             listener.getLogger().println("Command Step 2 - Scripts to Run: " + runner.getScripts());
 
-            
+
             //Step 3: other command line flags
-            if (!sut.isEmpty())      runner.setHost(sut);
+            if (!sut.isEmpty())      runner.setHost(getResolvedString(sut, build, listener));
             if (!port.isEmpty())     runner.setPort(Integer.parseInt(port));
-            if (!password.isEmpty()) runner.setPassword(password);
-            if (!colorDepth.isEmpty()) runner.setColorDepth(Integer.parseInt(colorDepth));
-            if (!defaultDocumentDirectory.isEmpty()) runner.setDefaultDocumentDirectory(defaultDocumentDirectory);
+            if (!password.isEmpty()) runner.setPassword(getResolvedString(password, build, listener));
+            if (!colorDepth.isEmpty()) runner.setColorDepth(Integer.parseInt(getResolvedString(colorDepth, build, listener)));
+
             if (reportFailures) runner.setReportFailures(reportFailures);
             if (commandLineOutput) runner.setCommandLineOutput(commandLineOutput);
             if (!params.isEmpty()) runner.setParams(params);
 
-            if (globalResultsFolder.isEmpty()){
-                epWorkingDir = build.getRootDir().getAbsolutePath();
-                runner.setGlobalResultsFolder(epWorkingDir);
-            } 
-            else {
-               runner.setGlobalResultsFolder(globalResultsFolder);
+            if (defaultDocumentDirectory.isEmpty()) {
+                runner.setDefaultDocumentDirectory(build.getWorkspace().toString());
+
+            } else {
+                runner.setDefaultDocumentDirectory(getResolvedString(defaultDocumentDirectory, build, listener));
             }
-            
+
+            if (globalResultsFolder.isEmpty()){
+                runner.setGlobalResultsFolder(build.getRootDir().getAbsolutePath());
+            }
+            else {
+                runner.setGlobalResultsFolder(getResolvedString(globalResultsFolder, build, listener));
+            }
+
             listener.getLogger().println("Command Step 3 - Other Command Line Flags,"
                     +"Host: "+runner.getHost()
                     +", Port: "+runner.getPort()
@@ -198,20 +223,20 @@ public class eggPlantBuilder extends Builder {
                     +", Color Depth: "+runner.getColorDepth()
                     +", Global Results Folder: "+runner.getGlobalResultsFolder()
                     +", Default Document Directory: "+runner.getDefaultDocumentDirectory());
-            
+
             //step 4: put the runscript command together
             runner.buildRunscriptCommandString();
-            
+
             listener.getLogger().println("Fully Constructed Runscript Command: "
                     +runner.getRunScriptCommandString());
-            
+
             //  runner object will be run from the command line
-            listener.getLogger().println("Now Executing" + 
+            listener.getLogger().println("Now Executing" +
                     runner.getRunScriptCommandString()+"...");
-            
+
             //JN: executes ONLY on the same machine as Jenkins
-                Process ls_proc = Runtime.getRuntime().exec(runner.getRunScriptCommandString());
-            
+            Process ls_proc = Runtime.getRuntime().exec(runner.getRunScriptCommandString());
+
             //  TODO: Distributed executions
             //Something like this will run on a distributed machine
             //launcher.launch().cmds(runner).stdout(listener.getLogger());  
@@ -242,10 +267,10 @@ public class eggPlantBuilder extends Builder {
             action = new eggPlantAction(build);
             build.addAction(action);
         }
-        
+
         EggplantParser parser = new EggplantParser();
         scripts = script.split(",");
-        
+
         //  Get the files in the build job directory
         File[] files = build.getRootDir().listFiles();
         boolean passed = true;
@@ -266,24 +291,24 @@ public class eggPlantBuilder extends Builder {
                 j++;
             }
         }
-        
+
         //  eggPlant has finished
         listener.getLogger().println("eggPlant parsing results finished");
 
         //  Return the result of the eggPlant bit
         return passed;
     }
-    
+
     /**
      * Descriptor for {@link eggPlantBuilder}. Used as a singleton.
      * The class is marked as public so that it can be accessed from views.
      */
-    
+
     @Override
     public DescriptorImpl getDescriptor() {
         return (DescriptorImpl) super.getDescriptor();
     }
-    
+
     @Extension // This indicates to Jenkins that this is an implementation of an extension point.
     public static final class DescriptorImpl extends BuildStepDescriptor<Builder> {
 
@@ -295,7 +320,7 @@ public class eggPlantBuilder extends Builder {
          * If you don't want fields to be persisted, use <tt>transient</tt>.
          */
         private String commandLine;
-      
+
         /**
          * Performs on-the-fly validation of the form field 'name'.
          *
@@ -309,7 +334,7 @@ public class eggPlantBuilder extends Builder {
             if (value.length() == 0) {
                 return FormValidation.error("Please set the location of runscript");
             }
-            
+
             return FormValidation.ok();
         }
         @Override
@@ -318,7 +343,7 @@ public class eggPlantBuilder extends Builder {
             return true;
         }
 
- 
+
         @Override
         public String getDisplayName() {
             return "eggPlant Configuration";
@@ -332,7 +357,7 @@ public class eggPlantBuilder extends Builder {
             save();
             return super.configure(req, formData);
         }
-        
+
         public String getCommandLine(){
             return commandLine;
         }


### PR DESCRIPTION
This change allow the user to enter Jenkins build variables into the command line flags configuration.  For example you can set up a parameterised build variable SUT with choices 192.168.2.2, 192.168.2.6 and then use ${SUT} in the eggPlant Configuration SUT field.
